### PR TITLE
Do not print exceptions on stdout

### DIFF
--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -242,7 +242,6 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         }
     }
 
-
     private void reportError(XTriggerLog log, Throwable e) {
         log.error("Polling error...");
         String message = e.getMessage();
@@ -252,9 +251,8 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         Throwable cause = e.getCause();
         if (cause != null) {
             log.error("Error cause: " + cause.getMessage());
-            cause.printStackTrace();
         }
-        e.printStackTrace();
+        LOGGER.log(Level.WARNING, "Polling failed", e);
     }
 
     protected Action[] getScheduledXTriggerActions(Node pollingNode, XTriggerLog log) throws XTriggerException {


### PR DESCRIPTION
I presume this is an error Jenkins admins can be interested in. Otherwise, we can simply send full stacktrace to `XTriggerLog`.