### PR TITLE
Plugin pom 2.x version bump and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# xtrigger lib
+
+Provides abstraction for common trigger plugin components

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jenkins.core.version>1.625.3</jenkins.core.version>
-        <envinject.version>1.0</envinject.version>
     </properties>
 
     <scm>
@@ -50,7 +49,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject-api</artifactId>
-            <version>${envinject.version}</version>
+            <version>1.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30</version>
+        <version>2.29</version>
     </parent>
 
     <groupId>org.jenkins-ci.lib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <envinject-lib.version>1.19</envinject-lib.version>
+        <envinject-lib.version>1.24</envinject-lib.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.0</version>
+        <version>2.30</version>
     </parent>
 
     <groupId>org.jenkins-ci.lib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>jenkins</artifactId>
-        <version>1.21</version>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>2.0</version>
     </parent>
 
     <groupId>org.jenkins-ci.lib</groupId>
@@ -38,37 +38,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <jenkins.core.version>1.480</jenkins.core.version>
         <envinject-lib.version>1.19</envinject-lib.version>
     </properties>
 
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/xtrigger-lib.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/xtrigger-lib.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-core</artifactId>
-            <version>${jenkins.core.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.lib</groupId>
             <artifactId>envinject-lib</artifactId>
             <version>${envinject-lib.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>${jenkins.core.version}</version>
-        </dependency>
-
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.29</version>
+        <version>2.30</version>
     </parent>
 
     <groupId>org.jenkins-ci.lib</groupId>
@@ -36,7 +36,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <envinject-lib.version>1.24</envinject-lib.version>
+        <jenkins.core.version>1.625.3</jenkins.core.version>
+        <envinject.version>1.0</envinject.version>
     </properties>
 
     <scm>
@@ -47,9 +48,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.lib</groupId>
-            <artifactId>envinject-lib</artifactId>
-            <version>${envinject-lib.version}</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>envinject-api</artifactId>
+            <version>${envinject.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -28,7 +28,7 @@ import jenkins.model.Jenkins;
  */
 public abstract class AbstractTrigger extends Trigger<BuildableItem> implements Serializable {
 
-    protected static Logger LOGGER = Logger.getLogger(AbstractTrigger.class.getName());
+    protected final static Logger LOGGER = Logger.getLogger(AbstractTrigger.class.getName());
 
     private String triggerLabel;
 
@@ -131,7 +131,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         try {
             StreamTaskListener listener = new StreamTaskListener(getLogFile());
             log = new XTriggerLog(listener);
-            if (Hudson.getInstance().isQuietingDown()) {
+            if (Jenkins.getActiveInstance().isQuietingDown()) {
                 log.info("Jenkins is quieting down.");
             } else if (!project.isBuildable()) {
                 log.info("The job is not buildable. Activate it to poll again.");
@@ -154,13 +154,14 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     protected abstract String getName();
 
     public XTriggerDescriptor getDescriptor() {
-        return (XTriggerDescriptor) Hudson.getInstance().getDescriptorOrDie(getClass());
+        return (XTriggerDescriptor) Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
     }
 
     /**
      * Asynchronous task
+     * TODO: removed Serializable, unsure why it was originally there
      */
-    private class Runner implements Runnable, Serializable {
+    private class Runner implements Runnable {
 
         private String triggerName;
 
@@ -368,7 +369,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
                 return Arrays.asList(getMasterNode());
             }
 
-            Label targetLabel = Hudson.getInstance().getLabel(triggerLabel);
+            Label targetLabel = Jenkins.getActiveInstance().getLabel(triggerLabel);
             return getNodesLabel(project, targetLabel);
         }
 
@@ -389,7 +390,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
                 return Arrays.asList(getMasterNode());
             }
 
-            Label targetLabel = Hudson.getInstance().getLabel(triggerLabel);
+            Label targetLabel = Jenkins.getActiveInstance().getLabel(triggerLabel);
             return getNodesLabel(project, targetLabel);
         }
 
@@ -431,7 +432,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         if (targetLabel != null) {
             return getNodesLabel(project, targetLabel);
         } else {
-            return Jenkins.getInstance().getNodes();
+            return Jenkins.getActiveInstance().getNodes();
         }
     }
 
@@ -450,7 +451,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     }
 
     private Node getMasterNode() {
-        Computer computer = Hudson.getInstance().toComputer();
+        Computer computer = Jenkins.getActiveInstance().toComputer();
         if (computer != null) {
             return computer.getNode();
         } else {

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -159,12 +159,11 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     protected abstract String getName();
 
     public XTriggerDescriptor getDescriptor() {
-        return (XTriggerDescriptor) Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
+        return (XTriggerDescriptor) super.getDescriptor();
     }
 
     /**
      * Asynchronous task
-     * TODO: removed Serializable, unsure why it was originally there
      */
     private class Runner implements Runnable {
 
@@ -174,6 +173,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
             this.triggerName = triggerName;
         }
 
+        @Override
         public void run() {
             XTriggerLog log = null;
             try {

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -106,6 +106,11 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
 
     /**
      * Can be overridden if needed
+     * @param pollingNode the node where the polling needs to be done
+     * @param project the project to trigger
+     * @param newInstance true if the trigger is new, false the trigger is loaded from disk
+     * @param log the XTrigger logger
+     * @throws XTriggerException This is a blanket throws for any problem that occurs while starting a trigger
      */
     protected void start(Node pollingNode, BuildableItem project, boolean newInstance, XTriggerLog log) throws XTriggerException {
     }
@@ -278,7 +283,10 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     /**
      * Checks if there are modifications in the environment between last poll
      *
+     * @param pollingNode the node to poll for modifications
+     * @param log the logger for the trigger
      * @return true if there are modifications
+     * @throws XTriggerException if there is an issue polling the node
      */
     protected abstract boolean checkIfModified(Node pollingNode, XTriggerLog log) throws XTriggerException;
 
@@ -298,7 +306,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     protected abstract String getCause();
 
     /**
-     * Get the node where the polling need to be done
+     * Get the node where the polling needs to be done
      * <p/>
      * The returned node has a number of executor different of 0.
      *

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -168,7 +168,6 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
             this.triggerName = triggerName;
         }
 
-        @Override
         public void run() {
             XTriggerLog log = null;
             try {

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
@@ -4,6 +4,8 @@ import antlr.ANTLRException;
 import hudson.model.BuildableItem;
 import hudson.model.Node;
 
+import java.io.ObjectStreamException;
+
 
 /**
  * @author Gregory Boissinot
@@ -14,12 +16,9 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
 
     private transient Object lock = new Object();
 
-    // make sure the lock is not null; when de-serialising
-    public Object readResolve() {
-        if(lock == null) {
-            lock = new Object();
-        }
-        return this;
+    protected Object readResolve() throws ObjectStreamException {
+        lock = new Object();
+        return super.readResolve();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
@@ -15,11 +15,11 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
     private transient Object lock = new Object();
 
     // make sure the lock is not null; when de-serialising
-    private Object getLock () {
-        if (lock == null) {
+    public Object readResolve() {
+        if(lock == null) {
             lock = new Object();
         }
-        return lock;
+        return this;
     }
 
     /**
@@ -60,7 +60,7 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
     @Override
     protected boolean checkIfModified(Node pollingNode, XTriggerLog log) throws XTriggerException {
 
-        synchronized (getLock()) {
+        synchronized (lock) {
             C newContext = getContext(pollingNode, log);
 
             if (offlineSlaveOnStartup) {
@@ -85,7 +85,7 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
     @Override
     protected boolean checkIfModified(XTriggerLog log) throws XTriggerException {
 
-        synchronized (getLock()) {
+        synchronized (lock) {
             C newContext = getContext(log);
 
             if (context == null) {
@@ -101,7 +101,7 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
 
     protected void setNewContext(C context) {
 
-        synchronized (getLock()) {
+        synchronized (lock) {
             this.context = context;
         }
     }
@@ -113,7 +113,7 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
      */
     protected void resetOldContext(C oldContext) {
 
-        synchronized (getLock()) {
+        synchronized (lock) {
             this.context = oldContext;
         }
     }

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
@@ -14,6 +14,14 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
 
     private transient Object lock = new Object();
 
+    // make sure the lock is not null; when de-serialising
+    private Object getLock () {
+        if (lock == null) {
+            lock = new Object();
+        }
+        return lock;
+    }
+
     /**
      * Builds a trigger object
      * Calls an implementation trigger
@@ -52,13 +60,7 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
     @Override
     protected boolean checkIfModified(Node pollingNode, XTriggerLog log) throws XTriggerException {
 
-        // make sure the lock is not null; when de-serialising
-        if(lock==null){
-            lock = new Object();
-        }
-        
-        synchronized (lock) {
-
+        synchronized (getLock()) {
             C newContext = getContext(pollingNode, log);
 
             if (offlineSlaveOnStartup) {
@@ -82,13 +84,8 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
 
     @Override
     protected boolean checkIfModified(XTriggerLog log) throws XTriggerException {
-        
-        // make sure the lock is not null; when de-serialising
-        if(lock==null){
-            lock = new Object();
-        }
-        
-        synchronized (lock) {
+
+        synchronized (getLock()) {
             C newContext = getContext(log);
 
             if (context == null) {
@@ -103,13 +100,8 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
     }
 
     protected void setNewContext(C context) {
-        
-         // make sure the lock is not null; when de-serialising
-        if(lock==null){
-            lock = new Object();
-        }
-        
-        synchronized (lock) {
+
+        synchronized (getLock()) {
             this.context = context;
         }
     }
@@ -120,13 +112,8 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
      * @param oldContext the previous context
      */
     protected void resetOldContext(C oldContext) {
-        
-         // make sure the lock is not null; when de-serialising
-        if(lock==null){
-            lock = new Object();
-        }
-        
-        synchronized (lock) {
+
+        synchronized (getLock()) {
             this.context = oldContext;
         }
     }

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTriggerByFullContext.java
@@ -123,6 +123,10 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
      * This method is alternative to getContext(XTriggerLog log)
      * It must be overridden
      * from 0.26
+     * @param pollingNode the node to poll
+     * @param log the logger for xtrigger
+     * @return the context of the trigger
+     * @throws XTriggerException any error that occurs while getting the context
      */
     protected C getContext(Node pollingNode, XTriggerLog log) throws XTriggerException {
         return null;
@@ -133,6 +137,9 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
      * This method is alternative to getContext(Node pollingNode, XTriggerLog log)
      * It must be overridden
      * from 0.26
+     * @param log the logger for xtrigger
+     * @return the context of the trigger
+     * @throws XTriggerException any error that occurs while getting the context
      */
     protected C getContext(XTriggerLog log) throws XTriggerException {
         return null;
@@ -141,7 +148,11 @@ public abstract class AbstractTriggerByFullContext<C extends XTriggerContext> ex
     /**
      * Checks if there are modifications in the environment between last poll
      *
+     * @param oldContext the context of the last poll
+     * @param newContext the context of the new poll
+     * @param log the logger for xtrigger
      * @return true if there are modifications
+     * @throws XTriggerException any error that occurs while getting the context
      */
     protected abstract boolean checkIfModified(C oldContext, C newContext, XTriggerLog log) throws XTriggerException;
 

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -5,7 +5,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import jenkins.model.Jenkins;
 import hudson.model.TaskListener;
-import hudson.remoting.Callable;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 
@@ -44,7 +43,7 @@ public class XTriggerCause extends Cause {
         final XTriggerCauseAction causeAction = build.getAction(XTriggerCauseAction.class);
         if (causeAction != null) {
             try {
-                Jenkins.getInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
+                Jenkins.getActiveInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
                     public Void call() throws XTriggerException {
                         causeAction.setBuild(build);
                         File triggerLogFile = causeAction.getLogFile();

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -3,9 +3,7 @@ package org.jenkinsci.lib.xtrigger;
 import hudson.console.HyperlinkNote;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
-import jenkins.model.Jenkins;
 import hudson.model.TaskListener;
-import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -27,9 +25,7 @@ public class XTriggerCause extends Cause {
     private boolean logEnabled;
 
     protected XTriggerCause(String triggerName, String causeFrom) {
-        this.triggerName = triggerName;
-        this.causeFrom = causeFrom;
-        this.logEnabled = false;
+        this(triggerName, causeFrom, false);
     }
 
     protected XTriggerCause(String triggerName, String causeFrom, boolean logEnabled) {
@@ -43,23 +39,14 @@ public class XTriggerCause extends Cause {
         final XTriggerCauseAction causeAction = build.getAction(XTriggerCauseAction.class);
         if (causeAction != null) {
             try {
-                Jenkins.getActiveInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
-                    public Void call() throws XTriggerException {
-                        causeAction.setBuild(build);
-                        File triggerLogFile = causeAction.getLogFile();
-                        String logContent = causeAction.getLogMessage();
-                        try {
-                            FileUtils.writeStringToFile(triggerLogFile, logContent);
-                        } catch (IOException ioe) {
-                            throw new XTriggerException(ioe);
-                        }
-                        return null;
-                    }
-                });
-            } catch (IOException ioe) {
-                LOGGER.log(Level.SEVERE, "Problem to attach cause object to build object.", ioe);
-            } catch (InterruptedException ie) {
-                LOGGER.log(Level.SEVERE, "Problem to attach cause object to build object.", ie);
+                causeAction.setBuild(build);
+                File triggerLogFile = causeAction.getLogFile();
+                String logContent = causeAction.getLogMessage();
+                try {
+                    FileUtils.writeStringToFile(triggerLogFile, logContent);
+                } catch (IOException ioe) {
+                    throw new XTriggerException(ioe);
+                }
             } catch (XTriggerException xe) {
                 LOGGER.log(Level.SEVERE, "Problem to attach cause object to build object.", xe);
             }

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -42,13 +42,9 @@ public class XTriggerCause extends Cause {
                 causeAction.setBuild(build);
                 File triggerLogFile = causeAction.getLogFile();
                 String logContent = causeAction.getLogMessage();
-                try {
-                    FileUtils.writeStringToFile(triggerLogFile, logContent);
-                } catch (IOException ioe) {
-                    throw new XTriggerException(ioe);
-                }
-            } catch (XTriggerException xe) {
-                LOGGER.log(Level.SEVERE, "Problem to attach cause object to build object.", xe);
+                FileUtils.writeStringToFile(triggerLogFile, logContent);
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Problem to attach cause object to build object.", e);
             }
         }
     }

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -3,9 +3,10 @@ package org.jenkinsci.lib.xtrigger;
 import hudson.console.HyperlinkNote;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import hudson.model.TaskListener;
 import hudson.remoting.Callable;
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -43,8 +44,7 @@ public class XTriggerCause extends Cause {
         final XTriggerCauseAction causeAction = build.getAction(XTriggerCauseAction.class);
         if (causeAction != null) {
             try {
-                Hudson.getInstance().getRootPath().act(new Callable<Void, XTriggerException>() {
-                    @Override
+                Jenkins.getInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
                     public Void call() throws XTriggerException {
                         causeAction.setBuild(build);
                         File triggerLogFile = causeAction.getLogFile();

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCauseAction.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCauseAction.java
@@ -37,12 +37,10 @@ public class XTriggerCauseAction implements Action {
         return logMessage;
     }
 
-    @Override
     public String getIconFileName() {
         return null;
     }
 
-    @Override
     public String getDisplayName() {
         return null;
     }
@@ -52,7 +50,6 @@ public class XTriggerCauseAction implements Action {
         return build;
     }
 
-    @Override
     public final String getUrlName() {
         return URL_NAME;
     }

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCauseAction.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCauseAction.java
@@ -37,10 +37,12 @@ public class XTriggerCauseAction implements Action {
         return logMessage;
     }
 
+    @Override
     public String getIconFileName() {
         return null;
     }
 
+    @Override
     public String getDisplayName() {
         return null;
     }
@@ -50,6 +52,7 @@ public class XTriggerCauseAction implements Action {
         return build;
     }
 
+    @Override
     public final String getUrlName() {
         return URL_NAME;
     }

--- a/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
+++ b/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
@@ -87,7 +87,7 @@ public class TestTrigger extends AbstractTrigger {
         return "Triggered by test";
     }
 
-    public String getLog() throws IOException {
+    public String getLog() throws Exception {
         return new FilePath(getLogFile()).readToString();
     }
 


### PR DESCRIPTION
This PR contains no new functionality, but only a plugin pom version bump and findbugs fixes. This bump is required to make this plugin and several other trigger plugins pipeline compatible. 

- [X] Bump plugin pom version
- [X] Fix tests and findbugs
- [x] Change deprecated dependency of evninject-lib to envinject-api plugin

@reviewbybees