### PR TITLE
Fix for JENKINS-33691 URLTrigger Plugin doesn't work in jenkins 2.0 alpha 3 when using job type Pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <jenkins.core.version>1.568</jenkins.core.version>
-        <envinject-lib.version>1.19</envinject-lib.version>
     </properties>
 
     <scm>
@@ -55,12 +54,6 @@
             <artifactId>jenkins-core</artifactId>
             <version>${jenkins.core.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.lib</groupId>
-            <artifactId>envinject-lib</artifactId>
-            <version>${envinject-lib.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.21</version>
+        <version>1.37</version>
     </parent>
 
     <groupId>org.jenkins-ci.lib</groupId>
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <jenkins.core.version>1.480</jenkins.core.version>
+        <jenkins.core.version>1.568</jenkins.core.version>
         <envinject-lib.version>1.19</envinject-lib.version>
     </properties>
 

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -4,6 +4,7 @@ import antlr.ANTLRException;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.*;
+import hudson.model.queue.SubTask;
 import hudson.triggers.Trigger;
 import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
@@ -20,6 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
 
 /**
  * @author Gregory Boissinot
@@ -110,7 +112,6 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
 
     @Override
     public void run() {
-        AbstractProject project = (AbstractProject) job;
         XTriggerDescriptor descriptor = getDescriptor();
         ExecutorService executorService = descriptor.getExecutor();
         XTriggerLog log = null;
@@ -119,9 +120,9 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
             log = new XTriggerLog(listener);
             if (Hudson.getInstance().isQuietingDown()) {
                 log.info("Jenkins is quieting down.");
-            } else if (!project.isBuildable()) {
+            } else if (!((Job<?, ?>) job).isBuildable()) {
                 log.info("The job is not buildable. Activate it to poll again.");
-            } else if (!unblockConcurrentBuild && project.isBuilding()) {
+            } else if (!unblockConcurrentBuild && ((Job<?, ?>) job).isBuilding()) {
                 log.info("The job is building. Waiting for next poll.");
             } else {
                 Runner runner = new Runner(getName());
@@ -196,8 +197,13 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
 
                 if (changed) {
                     log.info("Changes found. Scheduling a build.");
-                    AbstractProject project = (AbstractProject) job;
-                    project.scheduleBuild(0, new XTriggerCause(triggerName, getCause(), true), getScheduledXTriggerActions(null, log));
+                    ParameterizedJobMixIn<?, ?> scheduledJob = new ParameterizedJobMixIn() {
+                        @Override
+                        protected Job<?, ?> asJob() {
+                            return (Job<?, ?>) job;
+                        }
+                    };
+                    scheduledJob.scheduleBuild2(0, getScheduledXTriggerActions(null, log, triggerName));
                 } else {
                     log.info("No changes.");
                 }
@@ -244,14 +250,16 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         LOGGER.log(Level.WARNING, "Polling failed", e);
     }
 
-    protected Action[] getScheduledXTriggerActions(Node pollingNode, XTriggerLog log) throws XTriggerException {
+    protected Action[] getScheduledXTriggerActions(Node pollingNode, XTriggerLog log, String triggerName)
+            throws XTriggerException {
         Action[] actions = getScheduledActions(pollingNode, log);
-        int nbNewAction = actions.length + 1;
+        int nbNewAction = actions.length + 2;
         Action[] newActions = new Action[nbNewAction];
         for (int i = 0; i < actions.length; i++) {
             newActions[i] = actions[i];
         }
         try {
+            newActions[newActions.length - 2] = new CauseAction(new XTriggerCause(triggerName, getCause(), true));
             newActions[newActions.length - 1] = new XTriggerCauseAction(FileUtils.readFileToString(getLogFile()));
         } catch (IOException ioe) {
             throw new XTriggerException(ioe);
@@ -344,8 +352,6 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
 
     private List<Node> getPollingNodeListRequiredNoWS(XTriggerLog log) {
 
-        AbstractProject project = (AbstractProject) job;
-
         //The specified trigger node must be considered first
         if (triggerLabel != null) {
             log.info(String.format("Looking for a node to the restricted label %s.", triggerLabel));
@@ -356,15 +362,13 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
             }
 
             Label targetLabel = Hudson.getInstance().getLabel(triggerLabel);
-            return getNodesLabel(project, targetLabel);
+            return getNodesLabel((SubTask) job, targetLabel);
         }
 
         return candidatePollingNode(log);
     }
 
     private List<Node> getPollingNodeListRequiredWS(XTriggerLog log) {
-
-        AbstractProject project = (AbstractProject) job;
 
         //The specified trigger node must be considered first
         if (triggerLabel != null) {
@@ -377,12 +381,12 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
             }
 
             Label targetLabel = Hudson.getInstance().getLabel(triggerLabel);
-            return getNodesLabel(project, targetLabel);
+            return getNodesLabel((SubTask) job, targetLabel);
         }
 
         //Search for the last built on
         log.info("Looking for the last built on node.");
-        Node lastBuildOnNode = project.getLastBuiltOn();
+        Node lastBuildOnNode = ((SubTask) job).getLastBuiltOn();
         if (lastBuildOnNode == null) {
             return getPollingNodeNoPreviousBuild(log);
         }
@@ -402,21 +406,19 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     }
 
     private List<Node> getPollingNodeNoPreviousBuild(XTriggerLog log) {
-        AbstractProject project = (AbstractProject) job;
         Label targetLabel = getTargetLabel(log);
         if (targetLabel != null) {
-            return getNodesLabel(project, targetLabel);
+            return getNodesLabel((SubTask) job, targetLabel);
         }
         return null;
     }
 
     private List<Node> candidatePollingNode(XTriggerLog log) {
         log.info("Looking for a candidate node to run the poll.");
-        AbstractProject project = (AbstractProject) job;
 
         Label targetLabel = getTargetLabel(log);
         if (targetLabel != null) {
-            return getNodesLabel(project, targetLabel);
+            return getNodesLabel((SubTask) job, targetLabel);
         } else {
             return Jenkins.getInstance().getNodes();
         }
@@ -426,8 +428,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
      * Returns the label if any to poll
      */
     private Label getTargetLabel(XTriggerLog log) {
-        AbstractProject p = (AbstractProject) job;
-        Label assignedLabel = p.getAssignedLabel();
+        Label assignedLabel = ((SubTask) job).getAssignedLabel();
         if (assignedLabel != null) {
             log.info(String.format("Trying to find an eligible node with the assigned project label %s.", assignedLabel));
             return assignedLabel;
@@ -445,14 +446,14 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         }
     }
 
-    private List<Node> getNodesLabel(AbstractProject project, Label label) {
+    private List<Node> getNodesLabel(SubTask subTask, Label label) {
         List<Node> result = new ArrayList<Node>();
         List<Node> remainingNodes = new ArrayList<Node>();
 
         Set<Node> nodes = label.getNodes();
         for (Node node : nodes) {
             if (node != null) {
-                if (!isAPreviousBuildNode(project)) {
+                if (!isAPreviousBuildNode(subTask)) {
                     FilePath nodePath = node.getRootPath();
                     if (nodePath != null) {
                         result.add(node);
@@ -461,7 +462,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
                     FilePath nodeRootPath = node.getRootPath();
                     if (nodeRootPath != null) {
                         //We recommend first the samed node
-                        Node lastBuildOnNode = project.getLastBuiltOn();
+                        Node lastBuildOnNode = subTask.getLastBuiltOn();
                         if (lastBuildOnNode != null && nodeRootPath.equals(lastBuildOnNode.getRootPath())) {
                             result.add(0, node);
                         } else {
@@ -479,8 +480,8 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         }
     }
 
-    private boolean isAPreviousBuildNode(AbstractProject project) {
-        Node lastBuildOnNode = project.getLastBuiltOn();
+    private boolean isAPreviousBuildNode(SubTask subTask) {
+        Node lastBuildOnNode = subTask.getLastBuiltOn();
         return lastBuildOnNode != null;
     }
 

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -9,8 +9,6 @@ import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 
 import org.apache.commons.io.FileUtils;
-import org.jenkinsci.lib.envinject.EnvInjectException;
-import org.jenkinsci.lib.envinject.service.EnvVarsResolver;
 
 import java.io.File;
 import java.io.IOException;
@@ -108,18 +106,6 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
      * Can be overridden if needed
      */
     protected void start(Node pollingNode, BuildableItem project, boolean newInstance, XTriggerLog log) throws XTriggerException {
-    }
-
-    @SuppressWarnings("unused")
-    protected String resolveEnvVars(String value, AbstractProject project, Node node) throws XTriggerException {
-        EnvVarsResolver varsResolver = new EnvVarsResolver();
-        Map<String, String> envVars;
-        try {
-            envVars = varsResolver.getPollingEnvVars(project, node);
-        } catch (EnvInjectException envInjectException) {
-            throw new XTriggerException(envInjectException);
-        }
-        return Util.replaceMacro(value, envVars);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.lib.xtrigger;
 
 import hudson.console.HyperlinkNote;
-import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Hudson;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.Callable;
 import org.apache.commons.io.FileUtils;
@@ -39,14 +39,14 @@ public class XTriggerCause extends Cause {
     }
 
     @Override
-    public void onAddedTo(final AbstractBuild build) {
-        final XTriggerCauseAction causeAction = build.getAction(XTriggerCauseAction.class);
+    public void onAddedTo(final Run run) {
+        final XTriggerCauseAction causeAction = run.getAction(XTriggerCauseAction.class);
         if (causeAction != null) {
             try {
                 Hudson.getInstance().getRootPath().act(new Callable<Void, XTriggerException>() {
                     @Override
                     public Void call() throws XTriggerException {
-                        causeAction.setBuild(build);
+                        causeAction.setRun(run);
                         File triggerLogFile = causeAction.getLogFile();
                         String logContent = causeAction.getLogMessage();
                         try {

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCauseAction.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCauseAction.java
@@ -2,8 +2,8 @@ package org.jenkinsci.lib.xtrigger;
 
 import hudson.Util;
 import hudson.console.AnnotatedLargeText;
-import hudson.model.AbstractBuild;
 import hudson.model.Action;
+import hudson.model.Run;
 import org.apache.commons.jelly.XMLOutput;
 
 import java.io.File;
@@ -21,7 +21,7 @@ public class XTriggerCauseAction implements Action {
      * Set when the cause object is added to the build object
      * at job startup
      */
-    private AbstractBuild build;
+    private Run<?, ?> run;
 
     /**
      * Set on creation
@@ -48,8 +48,8 @@ public class XTriggerCauseAction implements Action {
     }
 
     @SuppressWarnings("unused")
-    public AbstractBuild getBuild() {
-        return build;
+    public Run<?, ?> getRun() {
+        return run;
     }
 
     @Override
@@ -57,15 +57,15 @@ public class XTriggerCauseAction implements Action {
         return URL_NAME;
     }
 
-    public void setBuild(AbstractBuild build) {
-        this.build = build;
+    public void setRun(Run<?, ?> run) {
+        this.run = run;
     }
 
     public File getLogFile() {
-        if (build == null) {
+        if (run == null) {
             return null;
         }
-        return new File(build.getRootDir(), "triggerlog.xml");
+        return new File(run.getRootDir(), "triggerlog.xml");
     }
 
     @SuppressWarnings("unused")
@@ -79,10 +79,10 @@ public class XTriggerCauseAction implements Action {
 
     @SuppressWarnings("unused")
     public String getTitle() {
-        if (build == null) {
+        if (run == null) {
             return "XTrigger Log";
         }
-        XTriggerCause triggerCause = (XTriggerCause) build.getCause(XTriggerCause.class);
+        XTriggerCause triggerCause = (XTriggerCause) run.getCause(XTriggerCause.class);
         if (triggerCause == null) {
             return "XTrigger Log";
         }

--- a/src/main/resources/org/jenkinsci/lib/xtrigger/XTriggerCauseAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/lib/xtrigger/XTriggerCauseAction/index.jelly
@@ -3,13 +3,13 @@
          xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <l:layout title="${it.displayName}">
         <j:invokeStatic var="currentThread" className="java.lang.Thread" method="currentThread"/>
-        <j:invoke var="buildClass" on="${currentThread.contextClassLoader}" method="loadClass">
-            <j:arg value="hudson.model.AbstractBuild"/>
+        <j:invoke var="runClass" on="${currentThread.contextClassLoader}" method="loadClass">
+            <j:arg value="hudson.model.Run"/>
         </j:invoke>
-        <j:set var="build" value="${request.findAncestorObject(buildClass)}"/>
-        <st:include page="sidepanel.jelly" it="${build}"/>
+        <j:set var="run" value="${request.findAncestorObject(runClass)}"/>
+        <st:include page="sidepanel.jelly" it="${run}"/>
         <l:main-panel>
-            <h1>${%Build} #${build.number}</h1>
+            <h1>${%Build} #${run.number}</h1>
             <l:pane title="${it.title}" width="3" />
             <j:set var="log" value="${it.log}"/>
             <j:choose>


### PR DESCRIPTION
`urltrigger-plugin`, `fstrigger-plugin`, and `scripttrigger-plugin` all depend on the common library `xtrigger-lib`. We need to push a fix to `xtrigger-lib`, then release a new version, and then update to that version in `urltrigger-plugin` in order to fix the bug. This is the first part of the change (the update to `urltrigger-plugin`).

See the commit messages for details on my thought process. I followed the advice on the [Pipeline Plugin's Developer Guide](https://github.com/jenkinsci/pipeline-plugin/blob/master/DEVGUIDE.md); namely, making sure my Jenkins baseline was at least 1.568 and getting rid of references to `AbstractBuild` and `AbstractProject`. I replaced these with the more generic `Run` and `Job`, respectively (as suggested). I also used `ParameterizedJobMixIn` to allow a job to be scheduled to the queue rather than `BuildableItem`, also as suggested in the above document.

I will open a separate pull request for the `urltrigger-plugin` changes and describe my testing of the whole fix there.