### PR TITLE
Mark unused protected function as deprecated

### DIFF
--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -110,7 +110,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     protected void start(Node pollingNode, BuildableItem project, boolean newInstance, XTriggerLog log) throws XTriggerException {
     }
 
-    @SuppressWarnings("unused")
+    @Deprecated // as of 0.34.
     protected String resolveEnvVars(String value, AbstractProject project, Node node) throws XTriggerException {
         EnvVarsResolver varsResolver = new EnvVarsResolver();
         Map<String, String> envVars;


### PR DESCRIPTION
We cannot remove the resolveEnvVars() function, even though it is not in
used by xtrigger, for compatibility reasons.  However, we can discourage
its use in future modules by marking it deprecated.