### PR TITLE
Reduce distance of downcast for job

### DIFF
--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -124,7 +124,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
 
     @Override
     public void run() {
-        AbstractProject project = (AbstractProject) job;
+        Job project = (Job) job;
         XTriggerDescriptor descriptor = getDescriptor();
         ExecutorService executorService = descriptor.getExecutor();
         XTriggerLog log = null;


### PR DESCRIPTION
Since AbstractBuild extends Job and no AbstractBuild methods are used
(only functions provided by Job are used), we can safely reduce the
distance of this downcast and retain all functionality in run().  This
allows the library to work with even more BuildableItems.