### PR TITLE
Remove unnecessary downcasting

### DIFF
--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -440,8 +440,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
      * Returns the label if any to poll
      */
     private Label getTargetLabel(XTriggerLog log) {
-        AbstractProject p = (AbstractProject) job;
-        Label assignedLabel = p.getAssignedLabel();
+        Label assignedLabel = job.getAssignedLabel();
         if (assignedLabel != null) {
             log.info(String.format("Trying to find an eligible node with the assigned project label %s.", assignedLabel));
             return assignedLabel;


### PR DESCRIPTION
The job object is cast from a BuildableItem into an AbstractProject, then
that AbstractProject calls getAssignedLabel().  However, the function is
specified in the BuildableItem interface; therefore, the original object
is sufficient without casting down to AbstractProject.  By removing this
unnecessary downcast, the program has one less runtime check to make.