### PR TITLE
Transition to Jenkins singleton, from Hudson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.21</version>
+        <version>1.37</version>
     </parent>
 
     <groupId>org.jenkins-ci.lib</groupId>
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <jenkins.core.version>1.480</jenkins.core.version>
+        <jenkins.core.version>1.590</jenkins.core.version>
         <envinject-lib.version>1.19</envinject-lib.version>
     </properties>
 

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -131,7 +131,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
         try {
             StreamTaskListener listener = new StreamTaskListener(getLogFile());
             log = new XTriggerLog(listener);
-            if (Hudson.getInstance().isQuietingDown()) {
+            if (Jenkins.getActiveInstance().isQuietingDown()) {
                 log.info("Jenkins is quieting down.");
             } else if (!project.isBuildable()) {
                 log.info("The job is not buildable. Activate it to poll again.");
@@ -154,7 +154,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     protected abstract String getName();
 
     public XTriggerDescriptor getDescriptor() {
-        return (XTriggerDescriptor) Hudson.getInstance().getDescriptorOrDie(getClass());
+        return (XTriggerDescriptor) Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -367,7 +367,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
                 return Arrays.asList(getMasterNode());
             }
 
-            Label targetLabel = Hudson.getInstance().getLabel(triggerLabel);
+            Label targetLabel = Jenkins.getActiveInstance().getLabel(triggerLabel);
             return getNodesLabel(job, targetLabel);
         }
 
@@ -386,7 +386,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
                 return Arrays.asList(getMasterNode());
             }
 
-            Label targetLabel = Hudson.getInstance().getLabel(triggerLabel);
+            Label targetLabel = Jenkins.getActiveInstance().getLabel(triggerLabel);
             return getNodesLabel(job, targetLabel);
         }
 
@@ -445,7 +445,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     }
 
     private Node getMasterNode() {
-        Computer computer = Hudson.getInstance().toComputer();
+        Computer computer = Jenkins.getActiveInstance().toComputer();
         if (computer != null) {
             return computer.getNode();
         } else {

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -3,8 +3,8 @@ package org.jenkinsci.lib.xtrigger;
 import hudson.console.HyperlinkNote;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
-import hudson.model.Hudson;
 import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 
@@ -43,7 +43,7 @@ public class XTriggerCause extends Cause {
         final XTriggerCauseAction causeAction = build.getAction(XTriggerCauseAction.class);
         if (causeAction != null) {
             try {
-                Hudson.getInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
+                Jenkins.getActiveInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
                     @Override
                     public Void call() throws XTriggerException {
                         causeAction.setBuild(build);

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -5,7 +5,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Hudson;
 import hudson.model.TaskListener;
-import hudson.remoting.Callable;
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -43,7 +43,7 @@ public class XTriggerCause extends Cause {
         final XTriggerCauseAction causeAction = build.getAction(XTriggerCauseAction.class);
         if (causeAction != null) {
             try {
-                Hudson.getInstance().getRootPath().act(new Callable<Void, XTriggerException>() {
+                Hudson.getInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
                     @Override
                     public Void call() throws XTriggerException {
                         causeAction.setBuild(build);

--- a/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
+++ b/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
@@ -87,7 +87,7 @@ public class TestTrigger extends AbstractTrigger {
         return "Triggered by test";
     }
 
-    public String getLog() throws IOException {
+    public String getLog() throws IOException, InterruptedException {
         return new FilePath(getLogFile()).readToString();
     }
 


### PR DESCRIPTION
In Jenkins, the Hudson object is a subclass of Jenkins, one that provides only deprecated functions (presumably for backwards compatibility).  Since xtrigger-lib does not use the deprecated functions, transition the project over to using the Jenkins object.

While unnecessary, this may help with maintainability into the future.